### PR TITLE
fix: pluralize upcoming event(s) only if needed

### DIFF
--- a/app/components/EventsList.tsx
+++ b/app/components/EventsList.tsx
@@ -12,7 +12,7 @@ export function EventsList({ events }: EventsListProps) {
 	return (
 		<>
 			<Heading className={styles.heading} level={2}>
-				Upcoming Events
+				Upcoming Event{events.length === 1 ? "" : "s"}
 			</Heading>
 
 			{events.map((event) => (


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #42
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/boston-ts-website/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/boston-ts-website/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds logic to the `"s"`.