### PR TITLE
feat: moved social links to the footer

### DIFF
--- a/app/components/Layout.css.ts
+++ b/app/components/Layout.css.ts
@@ -38,13 +38,21 @@ export const together = style({
 export const footer = style({
 	"@media": {
 		[breakpoints.medium]: {
-			alignItems: "flex-end",
-			bottom: "2rem",
-			flexDirection: "row",
-			justifyContent: "flex-end",
+			bottom: "1rem",
 			paddingBottom: "0",
 			position: "fixed",
 			right: "2rem",
+		},
+	},
+	paddingBottom: "1rem",
+});
+
+export const footerLinks = style({
+	"@media": {
+		[breakpoints.medium]: {
+			alignItems: "flex-end",
+			flexDirection: "row",
+			justifyContent: "flex-end",
 			textAlign: "right",
 		},
 	},
@@ -52,7 +60,7 @@ export const footer = style({
 	flexDirection: "column",
 	gap: "0.25rem",
 	justifyContent: "flex-end",
-	paddingBottom: "2rem",
+	paddingBottom: "1rem",
 });
 
 export const dot = style({

--- a/app/components/Layout.tsx
+++ b/app/components/Layout.tsx
@@ -5,6 +5,7 @@ import { HeroHeading } from "~/components/HeroHeading";
 import { InternalAnchor } from "./Anchor";
 import { Arrow } from "./Arrow";
 import * as styles from "./Layout.css";
+import { SocialsList } from "./SocialsList";
 
 export interface LayoutProps extends React.PropsWithChildren {
 	back?: boolean;
@@ -34,13 +35,16 @@ export function Layout({ back, children, title }: LayoutProps) {
 			</header>
 			<main className={styles.main}>{children}</main>
 			<footer className={styles.footer}>
-				<InternalAnchor reloadDocument to="/about" variant="heavy">
-					About
-				</InternalAnchor>
-				<span className={styles.dot} />
-				<InternalAnchor reloadDocument to="/code-of-conduct" variant="heavy">
-					Code of Conduct
-				</InternalAnchor>
+				<div className={styles.footerLinks}>
+					<InternalAnchor reloadDocument to="/about" variant="heavy">
+						About
+					</InternalAnchor>
+					<span className={styles.dot} />
+					<InternalAnchor reloadDocument to="/code-of-conduct" variant="heavy">
+						Code of Conduct
+					</InternalAnchor>
+				</div>
+				<SocialsList />
 			</footer>
 		</div>
 	);

--- a/app/components/SocialsList.css.ts
+++ b/app/components/SocialsList.css.ts
@@ -1,15 +1,22 @@
 import { style } from "@vanilla-extract/css";
 
+import { breakpoints } from "~/styles.css";
+
 export const socialsList = style({
+	"@media": {
+		[breakpoints.medium]: {
+			justifyContent: "space-between",
+			marginTop: "0.5rem",
+		},
+	},
 	display: "flex",
-	flexDirection: "column",
 	gap: "1rem",
 	listStyleType: "none",
+	margin: 0,
 	paddingLeft: 0,
 });
 
 export const logo = style({
 	height: "1rem",
-	marginRight: "1.5rem",
 	width: "1rem",
 });

--- a/app/components/SocialsList.tsx
+++ b/app/components/SocialsList.tsx
@@ -1,4 +1,4 @@
-import { AnchorWithArrow } from "./AnchorWithArrow";
+import { ExternalAnchor } from "./Anchor";
 import * as styles from "./SocialsList.css";
 import { BlueskyLogo } from "./logos/BlueskyLogo";
 import { DiscordLogo } from "./logos/DiscordLogo";
@@ -39,10 +39,9 @@ export function SocialsList() {
 		<ul className={styles.socialsList}>
 			{socials.map(({ href, logo: Logo, text }) => (
 				<li key={href}>
-					<AnchorWithArrow href={href} rel="me">
-						<Logo className={styles.logo} />
-						{text}
-					</AnchorWithArrow>
+					<ExternalAnchor href={href} rel="me" variant="heavy">
+						<Logo aria-label={text} className={styles.logo} />
+					</ExternalAnchor>
 				</li>
 			))}
 		</ul>

--- a/app/routes/about.tsx
+++ b/app/routes/about.tsx
@@ -4,7 +4,6 @@ import { ExternalAnchor } from "~/components/Anchor";
 import { BodyText } from "~/components/BodyText";
 import { Heading } from "~/components/Heading";
 import { Layout } from "~/components/Layout";
-import { SocialsList } from "~/components/SocialsList";
 import { createMeta, site } from "~/config";
 
 const tagline = `We meet once every month or two to chat about our favorite typed superset of JavaScript.`;
@@ -21,8 +20,6 @@ export default function About() {
 				learn new things, and show off their work.
 			</BodyText>
 			<BodyText>We're happy for you to join us.</BodyText>
-			<Heading level={3}>The Socials</Heading>
-			<SocialsList />
 			<Heading level={3}>The Team</Heading>
 			<BodyText>
 				Reach us over{" "}
@@ -33,13 +30,13 @@ export default function About() {
 				>
 					email
 				</ExternalAnchor>{" "}
-				or the{" "}
+				or{" "}
 				<ExternalAnchor
-					href="https://join.slack.com/t/bostonjavascript/shared_invite/zt-2emlu1b7m-6Ys9wprf~xY65GGOAioJrA"
+					href="https://discord.gg/kKTDgeaWmZ"
 					target="_blank"
 					variant="underline"
 				>
-					Boston JavaScript Slack
+					Discord
 				</ExternalAnchor>
 				.
 			</BodyText>

--- a/app/routes/code-of-conduct.tsx
+++ b/app/routes/code-of-conduct.tsx
@@ -22,7 +22,7 @@ export default function About() {
 				personal characteristics or choices, sexual images or comments in public
 				or online spaces, deliberate intimidation, bullying, stalking,
 				following, harassing photography or recording, sustained disruption of
-				talks, Slack messages, electronic meetings, physical meetings or other
+				talks, Discord messages, electronic meetings, physical meetings or other
 				events, inappropriate physical contact, or unwelcome sexual attention.
 				Participants asked to stop any harassing or bullying behavior are
 				expected to comply immediately.
@@ -31,14 +31,14 @@ export default function About() {
 				If a participant engages in harassing behavior, representatives of the
 				community may take reasonable action they deem appropriate, including
 				warning the offender, expulsion from any Boston TypeScript Club event,
-				or expulsion from mailing lists, Slack groups, discussion boards, and
+				or expulsion from mailing lists, Discord groups, discussion boards, and
 				other electronic communications channels to resolve the issue. This may
 				include expulsion from Boston TypeScript Club membership.
 			</BodyText>
 			<BodyText>
 				If you are being harassed, notice that someone else is being harassed,
 				or have any other concerns, please act to intercede or ask for help from
-				any member of the Boston TypeScript Club, Slack group admins, website
+				any member of the Boston TypeScript Club, Discord group admins, website
 				admins, or organizers/representatives of any physical events put on
 				under the auspices of the Boston TypeScript Club.
 			</BodyText>


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #161
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/boston-ts-website/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/boston-ts-website/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Moves `SocialsList` to the footer, and trims down the icon-and-text pairs to just be icons. I like this.